### PR TITLE
composer1.0に対応するためにsecure-httpをfalseにする

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "wpackagist-plugin/built-in-server-helper": "*"
     },
     "config": {
-        "vendor-dir": "www/wp-content/mu-plugins/vendor"
+        "vendor-dir": "www/wp-content/mu-plugins/vendor",
+        "secure-http": false
     },
     "extra": {
         "wordpress-install-dir": "www/wp",


### PR DESCRIPTION
composer1.0以降のバージョンだとエラーが出るようです。

```
$ composer create-project torounit/composer-wp-dev-kit

  [Composer\Downloader\TransportException]
  Your configuration does not allow connections to http://wpackagist.org/packages.json. See https://getcomposer.org
  /doc/06-config.md#secure-http for details
```

おそらくバージョン1.0からsecure-httpオプションが付いたからかと思います。
https://getcomposer.org/doc/06-config.md#secure-http
