### PR TITLE
Fix that not imported theme-unit-test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "wpackagist-plugin/theme-check": "*",
         "wpackagist-plugin/wp-multibyte-patch": "*",
         "wpackagist-plugin/jetpack": "^4.0",
-        "torounit/hello-kushimoto": "^2.9"
+        "torounit/hello-kushimoto": "^2.9",
+        "humanmade/WordPress-Importer": "dev-master"
     },
     "config": {
         "vendor-dir": "wp-content/mu-plugins/vendor"


### PR DESCRIPTION
```
$ composer import-theme-unit-test
...
Warning: The 'wordpress-importer' plugin could not be found.
Error: No plugins activated.
```